### PR TITLE
[Hacktoberfest] [API Docs]: Teacher yml files for /apidocs fixed. Closes #19

### DIFF
--- a/api/views/documentation/teachers/delete_teacher.yml
+++ b/api/views/documentation/teachers/delete_teacher.yml
@@ -1,0 +1,23 @@
+Delete a teacher
+---
+tags:
+  - Teachers
+summary: Delete a teacher by their ID
+parameters:
+  - in: path
+    name: teacher_id
+    description: ID of the event to delete
+    required: true
+    type: string
+responses:
+  204:
+    description: Event Deleted
+    schema:
+      type: object
+      properties:
+        message:
+          type: string
+          description: Message confirming event deletion
+          example: Event deleted
+  404:
+    description: Event not found

--- a/api/views/documentation/teachers/new_teachers.yml
+++ b/api/views/documentation/teachers/new_teachers.yml
@@ -1,0 +1,84 @@
+Adds a new teacher to the DB 
+---
+tags:
+  - Teachers
+summary: Create a new teacher
+parameters:
+  - in: body
+    name: teacher
+    description: Teacher object containing data
+    required: true
+    schema:
+      type: object
+      properties:
+        email:
+          type: string
+          description: Teacher's email
+        recovery_question:
+          type: string
+          description: Teacher's password recovery question
+        first_name:
+          type: string
+          description: Teacher's first name
+        last_name:
+          type: string
+          description: Teacher's last name
+        department_id:
+          type: string
+          description: The UUID of the department in which the teacher works
+        recovery_answer:
+          type: string
+          description: Tha answer to the recovery question
+        password:
+          type: string
+          description: Teacher's password
+      example:
+        created_at: "2017-03-25T02:17:06"
+        department_id: "53af4926-52ee-41d0-9acc-ae7230300003"
+        email: "DJUMARR@schub.com"
+        first_name: "DJUMARR"
+        last_name: "RINALDOR"
+        recovery_question: "What is the name of your childhood best friend?"
+        recovery_answer: "Amogus"
+        password: "12345678"
+responses:
+  200:
+    description: Teacher created successfully
+    schema:
+      type: object
+      properties:
+        created_at:
+          type: string
+          description: Time of creation of the Teacher
+        id:
+          type: string
+          description: The UUID of the Teacher
+        email:
+          type: string
+          description: Teacher's email
+        recovery_question:
+          type: string
+          description: Teacher's password recovery question
+        first_name:
+          type: string
+          description: Teacher's first name
+        last_name:
+          type: string
+          description: Teacher's last name
+        department:
+          type: string
+          description: Department in which the teacher works
+        department_id:
+          type: string
+          description: The UUID of the department in which the teacher works
+      example:
+        created_at: "2017-03-25T02:17:06"
+        department: "Agricultural Engineering"
+        department_id: "53af4926-52ee-41d0-9acc-ae7230300003"
+        email: "DJUMAR@schub.com"
+        first_name: "DJUMA"
+        id: "53af4926-52ee-41d0-9acc-ae7230400015"
+        last_name: "RINALDO"
+        recovery_question: "What is the name of your childhood best friend?"
+  400:
+    description: Bad request, invalid JSON or missing required fields

--- a/api/views/documentation/teachers/teacher.yml
+++ b/api/views/documentation/teachers/teacher.yml
@@ -1,7 +1,8 @@
-Retrieves a teacher from the DB
+Retrieves a teacher from the DB using their ID
 ---
 tags:
   - Teachers
+summary: Retrieve a teacher using their ID
 parameters:
   - name: teacher_id
     in: path

--- a/api/views/documentation/teachers/update_teacher.yml
+++ b/api/views/documentation/teachers/update_teacher.yml
@@ -1,0 +1,94 @@
+Updates a teacher in the DB using their ID
+---
+tags:
+  - Teachers
+summary: Update a teacher using their ID
+parameters:
+  - in: path
+    name: teacher_id
+    type: string
+    required: true
+    description: The id of the teacher to retrieve
+  - in: body
+    name: teacher_body
+    description: Update key, value dict for teacher
+    required: true
+    schema:
+      type: object
+      properties:
+        created_at:
+          type: string
+          description: Time of creation of the Teacher
+        id:
+          type: string
+          description: The UUID of the Teacher
+        email:
+          type: string
+          description: Teacher's email
+        recovery_question:
+          type: string
+          description: Teacher's password recovery question
+        first_name:
+          type: string
+          description: Teacher's first name
+        last_name:
+          type: string
+          description: Teacher's last name
+        department:
+          type: string
+          description: Department in which the teacher works
+        department_id:
+          type: string
+          description: The UUID of the department in which the teacher works
+      example:
+        created_at: "2017-03-25T02:17:06"
+        department: "Agricultural Engineering"
+        department_id: "53af4926-52ee-41d0-9acc-ae7230300003"
+        email: "DJUMAR@schub.com"
+        first_name: "DJUMA"
+        id: "53af4926-52ee-41d0-9acc-ae7230400015"
+        last_name: "RINALDO"
+        recovery_question: "What is the name of your childhood best friend?"
+responses:
+  201:
+    description: Event updated successfully
+    schema:
+      type: object
+      properties:
+        created_at:
+          type: string
+          description: Time of creation of the Teacher
+        id:
+          type: string
+          description: The UUID of the Teacher
+        email:
+          type: string
+          description: Teacher's email
+        recovery_question:
+          type: string
+          description: Teacher's password recovery question
+        first_name:
+          type: string
+          description: Teacher's first name
+        last_name:
+          type: string
+          description: Teacher's last name
+        department:
+          type: string
+          description: Department in which the teacher works
+        department_id:
+          type: string
+          description: The UUID of the department in which the teacher works
+      example:
+        created_at: "2017-03-25T02:17:06"
+        department: "Agricultural Engineering"
+        department_id: "53af4926-52ee-41d0-9acc-ae7230300003"
+        email: "DJUMAR@schub.com"
+        first_name: "DJUMA"
+        id: "53af4926-52ee-41d0-9acc-ae7230400015"
+        last_name: "RINALDO"
+        recovery_question: "What is the name of your childhood best friend?"
+  400:
+    description: Bad request, invalid JSON or missing required fields
+  404:
+    description: Teacher not found

--- a/api/views/teachers.py
+++ b/api/views/teachers.py
@@ -11,7 +11,8 @@ from flasgger.utils import swag_from
     '/teachers',
     methods=['GET', 'POST'],
     strict_slashes=False)
-@swag_from('documentation/teachers/teachers.yml')
+@swag_from('documentation/teachers/teachers.yml', methods=['GET'])
+@swag_from('documentation/teachers/new_teachers.yml', methods=['POST'])
 def teachers():
     """
         Configures GET and POST methods for the teachers route
@@ -66,7 +67,9 @@ def teachers():
     '/teachers/<teacher_id>',
     methods=['GET', 'PUT', 'DELETE'],
     strict_slashes=False)
-@swag_from('documentation/teachers/teacher.yml')
+@swag_from('documentation/teachers/teacher.yml', methods=['GET'])
+@swag_from('documentation/teachers/delete_teacher.yml', methods=['DELETE'])
+@swag_from('documentation/teachers/update_teacher.yml', methods=['PUT'])
 def teacher(teacher_id):
     """
         Configures GET, PUT and DELETE for the teacher route


### PR DESCRIPTION
Fixied teacher API Docs. Now all teacher routes in /apidocs work as expected. This closes #19 

This was fixed by:
- [x] Splitting yml files for each request type.
- [x] Writing yml for each method in its own file.
- [x] Attaching files to methods using the @swag_from decorator of flasgger.